### PR TITLE
verify official commit

### DIFF
--- a/.github/workflows/official_commit_verify.yml
+++ b/.github/workflows/official_commit_verify.yml
@@ -26,13 +26,13 @@ jobs:
         echo "commit_hash=$(git rev-parse --short=8 --verify HEAD)" >> $GITHUB_OUTPUT
     - name: Compare to expected commit hash
       run: |
+        echo "Expected: ${{ env.EXPECTED_COMMIT }}"
+        echo "Got:      ${{ steps.latest_official.outputs.commit_hash }}"
         if [ "${{ steps.latest_official.outputs.commit_hash }}" = "${{ env.EXPECTED_COMMIT }}" ]; then 
           echo "Commit hashes match."
           exit 0
         else
           echo "Commit hashes do not match."
-          echo "Expected: ${{ env.EXPECTED_COMMIT }}"
-          echo "Got:      ${{ steps.latest_official.outputs.commit_hash }}"
           echo "Regenerate test cases based on latest official commit (${{ steps.latest_official.outputs.commit_hash }}) and update this workflow file to acknowledge the updated official implementation."
           exit 1
         fi


### PR DESCRIPTION
added GitHub action workflow to verify the latest commit is known

failure of this action schould be a trigger to regenerate the test cases with the latest commit and update the workflow to make it known, that this is the commit the test cases are based upon