### PR TITLE
Update workflow to trigger only on release published

### DIFF
--- a/.github/workflows/push_nuget_packages.yml
+++ b/.github/workflows/push_nuget_packages.yml
@@ -4,10 +4,6 @@ on:
   release:
     types:
       - published
-  push:
-    tags:
-      - 'v[0-9]+.[0-9]+.[0-9]+' 
-      - 'v[0-9]+.[0-9]+.[0-9]+-*'
       
 env:
   PACKAGES_ARTIFACT: nuget-package-${{ github.event.release.tag_name }}
@@ -66,6 +62,9 @@ jobs:
       - build-package
     runs-on: ubuntu-latest
     
+    permissions:
+      contents: write
+      
     env:
       PACKAGE_DIR: 'packages'
 


### PR DESCRIPTION
Removed push event triggers for version tags in workflow.
Also added permission to write content, as this is required for the authorization when adding assets to a release.