### PR TITLE
use PAT instead of GITHUB_TOKEN

### DIFF
--- a/.github/workflows/create_tests.yml
+++ b/.github/workflows/create_tests.yml
@@ -102,7 +102,7 @@ jobs:
       - name: Create Pull Request
         if: steps.check_diff.outputs.has_changes == 'true'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GH_PAT_WORKFLOW }}
         run: |
           gh pr create \
             --base "master" \


### PR DESCRIPTION
So that the Pull Request that is created can run the GitHub Actions with the tests. Otherwise the 'pull_request' event is not triggered.