### PR TITLE
redirect commit SHA to `GITHUB_OUTPUT`

### DIFF
--- a/.github/workflows/create_tests.yml
+++ b/.github/workflows/create_tests.yml
@@ -121,7 +121,7 @@ jobs:
           path: ${{ env.TEST_THEME_DIR }}
 
       - name: Update offical commit hash the testcases are based on
-        run: cat ${{ needs.build-java.outputs.offical_commit }} > .github/workflows/official-commit/sha
+        run: echo "${{ needs.build-java.outputs.offical_commit }}" > .github/workflows/official-commit/sha
 
       - name: Check for changes in the testcases
         id: check_diff

--- a/.github/workflows/create_tests.yml
+++ b/.github/workflows/create_tests.yml
@@ -43,7 +43,7 @@ jobs:
         run: |
           COMMIT=$(cat .upstream-commit)
           echo "Testcase generation is based on official commit: $COMMIT"
-          echo "sha=$COMMIT"
+          echo "sha=$COMMIT" >> $GITHUB_OUTPUT
 
       - uses: actions/setup-java@v5
         with:


### PR DESCRIPTION
so the value is available in later steps and jobs