### PR TITLE
use the workflow PAT for checkout

### DIFF
--- a/.github/workflows/create_tests.yml
+++ b/.github/workflows/create_tests.yml
@@ -83,6 +83,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           ref: ${{ env.PR_TARGET_BRANCH_NAME }}
+          token: ${{ secrets.GH_PAT_WORKFLOW }} # so the actions will run when pushing to the PR branch
 
       - name: Check for existing branch
         id: existing_branch


### PR DESCRIPTION
so the actions can run even when the PR already exists, but new commits are pushed to the PR branch