### PR TITLE
Add GitHub Actions and NuGet to Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,20 @@
+version: 2
+updates:
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    assignees:
+    - Muckenbatscher
+    labels:
+    - dependencies
+
+  - package-ecosystem: nuget
+    directory: "/"
+    schedule:
+      interval: "daily"
+    assignees:
+    - Muckenbatscher
+    labels:
+    - dependencies

--- a/MaterialTheming.slnx
+++ b/MaterialTheming.slnx
@@ -4,8 +4,11 @@
     <File Path="README.md" />
   </Folder>
   <Folder Name="/Solution Items/GitHub/">
-    <File Path=".github/workflows/build_test_library.yml" />
+    <File Path=".github/dependabot.yml" />
+  </Folder>
+  <Folder Name="/Solution Items/GitHub/Workflows/">
     <File Path=".github/workflows/build_blazor.yml" />
+    <File Path=".github/workflows/build_test_library.yml" />
     <File Path=".github/workflows/create_tests.yml" />
     <File Path=".github/workflows/deploy_gh_pages.yml" />
     <File Path=".github/workflows/official_commit_verify.yml" />


### PR DESCRIPTION
Add a Dependabot configuration to include GitHub Actions and NuGet updates on a daily schedule.