### PR TITLE
Group NuGet dependencies in `dependabot.yml`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,7 +10,7 @@ updates:
     labels:
     - dependencies
 
-  - package-ecosystem: nuget
+  - package-ecosystem: "nuget"
     directory: "/"
     schedule:
       interval: "daily"
@@ -18,3 +18,11 @@ updates:
     - Muckenbatscher
     labels:
     - dependencies
+    groups:
+      mstest:
+        patterns:
+          - "MSTest*"
+      core:
+        patterns:
+          - "Microsoft*"
+          - "System*"


### PR DESCRIPTION
Added dependency groups for MSTest and Core dependencies (System.\*/Microsoft.\*) in NuGet