### PR TITLE
Update validate-semver to @v3

### DIFF
--- a/.github/workflows/push_nuget_packages.yml
+++ b/.github/workflows/push_nuget_packages.yml
@@ -15,7 +15,7 @@ jobs:
       version: ${{ steps.version.outputs.version }}
     steps:
     - name: Check Version Format in Tag
-      uses: matt-usurp/validate-semver@v2
+      uses: matt-usurp/validate-semver@v3
       id: version
       with:
         version: ${{ github.event.release.tag_name }}


### PR DESCRIPTION
Built on Node 24 to avoid a GitHub warning for using deprecated runner features.