### PR TITLE
separate job to determine the commit the tests are based on

### DIFF
--- a/.github/workflows/create_tests.yml
+++ b/.github/workflows/create_tests.yml
@@ -138,7 +138,7 @@ jobs:
       - name: Update official commit hash the testcases are based on
         run: echo "${{ needs.determine-based-commit.outputs.offical_commit }}" > .official-commit-sha
 
-      - name: Check for changes in the testcases
+      - name: Check for changes
         id: check_diff
         run: |
           git add ${{ env.TEST_THEME_DIR }}
@@ -147,10 +147,10 @@ jobs:
           CHANGES=$(git diff --staged --name-only)
 
           if [ -z "$CHANGES" ]; then
-            echo "No changes found in '${{ env.TEST_THEME_DIR }}'"
+            echo "No changes found."
             echo "has_changes=false" >> $GITHUB_OUTPUT
           else
-            echo "Changes detected in '${{ env.TEST_THEME_DIR }}'!"
+            echo "Changes detected!"
             echo "has_changes=true" >> $GITHUB_OUTPUT
           fi
 
@@ -163,7 +163,9 @@ jobs:
       - name: Commit and push generated tests
         if: steps.check_diff.outputs.has_changes == 'true'
         run: |
-          git commit -m "Update C# testcase files. Generated from Java reference implementation."
+          git commit \
+            -m "Update C# testcase files. Generated from Java reference implementation." \
+            -m "Based on official commit: ${{ needs.determine-based-commit.outputs.offical_commit }}"
           git push -u origin ${{ env.PR_SOURCE_BRANCH_NAME }}
 
   generate-pr:

--- a/.github/workflows/create_tests.yml
+++ b/.github/workflows/create_tests.yml
@@ -10,11 +10,40 @@ env:
   PR_SOURCE_BRANCH_NAME: test-generation
 
 jobs:
-  build-java:
+  determine-based-commit:
     runs-on: ubuntu-latest
-    
+
     outputs:
       offical_commit: ${{ steps.offical_commit.outputs.sha }}
+
+    env:
+      TEST_GEN_REPO: 'Muckenbatscher/material-color-utilities-testcases-generation'
+      TEST_GEN_BRANCH: 'main'
+      UPSTREAM_REPO: 'material-foundation/material-color-utilities'
+      UPSTREAM_BRANCH: 'main'
+
+    steps:
+      - name: Checkout Test generation repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0 # fetch whole history, to be able to compare and find the common commit with official repository
+          repository: ${{ env.TEST_GEN_REPO }}
+          ref: ${{ env.TEST_GEN_BRANCH }}
+
+      - name: Add official remote and fetch
+        run: |
+          git remote add official https://github.com/${{ env.UPSTREAM_REPO }}.git
+          git fetch official ${{ env.UPSTREAM_BRANCH }}
+
+      - name: Get official commit hash
+        id: offical_commit
+        run: |
+          COMMON_SHA=$(git merge-base origin/${{ env.TEST_GEN_BRANCH }} official/${{ env.UPSTREAM_BRANCH }})
+          echo "Test case generation is based on official commit: $COMMON_SHA"
+          echo "sha=$COMMON_SHA" >> $GITHUB_OUTPUT
+
+  build-java:
+    runs-on: ubuntu-latest
 
     env:
       TEST_GEN_REPO_NAME: Muckenbatscher/material-color-utilities-testcases-generation
@@ -27,13 +56,6 @@ jobs:
         with:
           repository: ${{ env.TEST_GEN_REPO_NAME }} 
           ref: ${{ env.TEST_GEN_REPO_BRANCH }}
-
-      - name: Get official commit hash
-        id: offical_commit
-        run: |
-          COMMIT=$(cat .upstream-commit)
-          echo "Testcase generation is based on official commit: $COMMIT"
-          echo "sha=$COMMIT" >> $GITHUB_OUTPUT
 
       - uses: actions/setup-java@v5
         with:
@@ -66,7 +88,9 @@ jobs:
           retention-days: 1 
   
   create-refs:
-    needs: build-java
+    needs: 
+      - determine-based-commit
+      - build-java
     runs-on: ubuntu-latest
 
     permissions:
@@ -81,6 +105,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
+          fetch-depth: 0 # fetch whole history, to be able to compare 
           ref: ${{ env.PR_TARGET_BRANCH_NAME }}
           token: ${{ secrets.GH_PAT_WORKFLOW }} # so the actions will run when pushing to the PR branch
 
@@ -110,8 +135,8 @@ jobs:
           name: generated-testcase-cs-files 
           path: ${{ env.TEST_THEME_DIR }}
 
-      - name: Update offical commit hash the testcases are based on
-        run: echo "${{ needs.build-java.outputs.offical_commit }}" > .official-commit-sha
+      - name: Update official commit hash the testcases are based on
+        run: echo "${{ needs.determine-based-commit.outputs.offical_commit }}" > .official-commit-sha
 
       - name: Check for changes in the testcases
         id: check_diff
@@ -150,8 +175,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
-        with:
-          fetch-depth: 0 # fetch whole history, to be able to compare 
       
       - name: Check for existing PR
         id: existing_pr


### PR DESCRIPTION
make the job to create refs dependent on both the java build and the determination of the common commit.
use the job output to write it to the file that tracks the official commit.