### PR TITLE
Add extension methods to convert to System.Windows.Media.Color

### DIFF
--- a/.github/workflows/push_nuget_packages.yml
+++ b/.github/workflows/push_nuget_packages.yml
@@ -29,6 +29,8 @@ jobs:
         project: 
           - name: MaterialTheming
             path: 'MaterialTheming/MaterialTheming.csproj'
+          - name: MaterialTheming.Wpf
+            path: 'MaterialTheming.Wpf/MaterialTheming.Wpf.csproj'
 
     env:
       VERSION: ${{ needs.version.outputs.version }} 

--- a/MaterialTheming.Wpf/MaterialTheming.Wpf.csproj
+++ b/MaterialTheming.Wpf/MaterialTheming.Wpf.csproj
@@ -1,0 +1,13 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net48;net8.0-windows;net10.0-windows</TargetFrameworks>
+    <UseWPF>true</UseWPF>
+    <EnableWindowsTargeting>true</EnableWindowsTargeting>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\MaterialTheming\MaterialTheming.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/MaterialTheming.Wpf/MaterialTheming.Wpf.csproj
+++ b/MaterialTheming.Wpf/MaterialTheming.Wpf.csproj
@@ -6,6 +6,15 @@
     <EnableWindowsTargeting>true</EnableWindowsTargeting>
   </PropertyGroup>
 
+  <!--Package metadata-->
+  <Import Project="..\NugetPackage.props" />
+
+  <PropertyGroup>
+    <PackageId>MaterialTheming.Wpf</PackageId>
+    <Description>Create customized themes with the Material 3 color system for WPF applications.</Description>
+    <PackageTags>$PackageTags;wpf</PackageTags>
+  </PropertyGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\MaterialTheming\MaterialTheming.csproj" />
   </ItemGroup>

--- a/MaterialTheming.Wpf/WindowsMediaColorExtensions.cs
+++ b/MaterialTheming.Wpf/WindowsMediaColorExtensions.cs
@@ -1,0 +1,32 @@
+using System.Windows.Media;
+
+namespace MaterialTheming;
+
+public static class WindowsMediaColorExtensions
+{
+    extension(RgbColor rgbColor)
+    {
+        public Color ToColor()
+        {
+            return Color.FromRgb(rgbColor.Red, rgbColor.Green, rgbColor.Blue);
+        }
+    }
+
+    extension(Color color)
+    {
+        public RgbColor ToRgbColor()
+        {
+            return RgbColor.FromRgb(color.R, color.G, color.B);
+        }
+    }
+
+    extension(HctColor hctColor)
+    {
+        public Color ToColor() => hctColor.ToRgbColor().ToColor();
+    }
+
+    extension(Color color)
+    {
+        public HctColor ToHctColor() => color.ToRgbColor().ToHct();
+    }
+}

--- a/MaterialTheming.Wpf/WindowsMediaColorExtensions.cs
+++ b/MaterialTheming.Wpf/WindowsMediaColorExtensions.cs
@@ -2,10 +2,18 @@ using System.Windows.Media;
 
 namespace MaterialTheming;
 
+/// <summary>
+/// Provides extension methods for converting between 
+/// <see cref="RgbColor"/>, <see cref="HctColor"/>, and the native <see cref="Color"/>.
+/// </summary>
 public static class WindowsMediaColorExtensions
 {
     extension(RgbColor rgbColor)
     {
+        /// <summary>
+        /// Converts the <see cref="RgbColor"/> to a native <see cref="Color"/>.
+        /// </summary>
+        /// <returns></returns>
         public Color ToColor()
         {
             return Color.FromRgb(rgbColor.Red, rgbColor.Green, rgbColor.Blue);
@@ -14,6 +22,10 @@ public static class WindowsMediaColorExtensions
 
     extension(Color color)
     {
+        /// <summary>
+        /// Converts the native <see cref="Color"/> to a <see cref="RgbColor"/>.
+        /// </summary>
+        /// <returns></returns>
         public RgbColor ToRgbColor()
         {
             return RgbColor.FromRgb(color.R, color.G, color.B);
@@ -22,11 +34,19 @@ public static class WindowsMediaColorExtensions
 
     extension(HctColor hctColor)
     {
+        /// <summary>
+        /// Converts the <see cref="HctColor"/> to a native <see cref="Color"/>.
+        /// </summary>
+        /// <returns></returns>
         public Color ToColor() => hctColor.ToRgbColor().ToColor();
     }
 
     extension(Color color)
     {
+        /// <summary>
+        /// Converts the native <see cref="Color"/> to a <see cref="HctColor"/>.
+        /// </summary>
+        /// <returns></returns>
         public HctColor ToHctColor() => color.ToRgbColor().ToHct();
     }
 }

--- a/MaterialTheming.slnx
+++ b/MaterialTheming.slnx
@@ -23,5 +23,6 @@
   </Folder>
   <Project Path="MaterialTheming.BlazorShowcase/MaterialTheming.BlazorShowcase.csproj" />
   <Project Path="MaterialTheming.Tests/MaterialTheming.Tests.csproj" />
+  <Project Path="MaterialTheming.Wpf/MaterialTheming.Wpf.csproj" />
   <Project Path="MaterialTheming/MaterialTheming.csproj" />
 </Solution>

--- a/MaterialTheming/MaterialTheming.csproj
+++ b/MaterialTheming/MaterialTheming.csproj
@@ -1,45 +1,15 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFrameworks>netstandard2.1;net48;net8.0;net10.0</TargetFrameworks>
-  </PropertyGroup>
-  
+	<PropertyGroup>
+		<TargetFrameworks>netstandard2.1;net48;net8.0;net10.0</TargetFrameworks>
+	</PropertyGroup>
+
 	<!--Package metadata-->
+	<Import Project="..\NugetPackage.props" />
+
 	<PropertyGroup>
 		<PackageId>MaterialTheming</PackageId>
 		<Description>Create customized themes with the Material 3 color system.</Description>
-		<Authors>Muckenbatscher</Authors>
-		<PackageReadmeFile>README.md</PackageReadmeFile>
-		<PackageIcon>material-design-primary-container.png</PackageIcon>
-		<PackageLicenseExpression>MIT</PackageLicenseExpression>
-		<PackageTags>material;theme;ui</PackageTags>
-	</PropertyGroup>
-
-  <!--XML Doc Comments-->
-  <PropertyGroup>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <!-- to not require every public facing method to have an xml-doc comment -->
-    <WarningsNotAsErrors>$(WarningsNotAsErrors);1591</WarningsNotAsErrors>
-  </PropertyGroup>
-	
-	<!--Package resources-->
-	<ItemGroup>
-		<None Include="..\README.md" Pack="true" PackagePath="\" />
-		<None Include="..\material-design-primary-container.png" Pack="true" PackagePath="\" />
-	</ItemGroup>
-
-	<!--SourceLink-->
-	<PropertyGroup>
-		<PublishRepositoryUrl>true</PublishRepositoryUrl>
-		<RepositoryType>git</RepositoryType>
-		<RepositoryUrl>https://github.com/Muckenbatscher/MaterialTheming</RepositoryUrl>
-		<PackageProjectUrl>https://github.com/Muckenbatscher/MaterialTheming</PackageProjectUrl>
-	</PropertyGroup>
-	<PropertyGroup Condition="'$(GITHUB_ACTIONS)' == 'true'">
-		<ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
-		<Deterministic>true</Deterministic>
-		<EmbedUntrackedSources>true</EmbedUntrackedSources>
-		<AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
 	</PropertyGroup>
 
 	<!--dependencies that are only required in specific target frameworks-->

--- a/NugetPackage.props
+++ b/NugetPackage.props
@@ -1,0 +1,38 @@
+<Project>
+
+	<!--Package metadata-->
+	<PropertyGroup>
+		<Authors>Muckenbatscher</Authors>
+		<PackageReadmeFile>README.md</PackageReadmeFile>
+		<PackageIcon>material-design-primary-container.png</PackageIcon>
+		<PackageLicenseExpression>MIT</PackageLicenseExpression>
+		<PackageTags>material;theme;ui</PackageTags>
+	</PropertyGroup>
+
+	<!--XML Doc Comments-->
+	<PropertyGroup>
+		<GenerateDocumentationFile>true</GenerateDocumentationFile>
+		<!-- to not require every public facing method to have an xml-doc comment -->
+		<WarningsNotAsErrors>$(WarningsNotAsErrors);1591</WarningsNotAsErrors>
+	</PropertyGroup>
+
+	<!--Package resources-->
+	<ItemGroup>
+		<None Include="..\README.md" Pack="true" PackagePath="\" />
+		<None Include="..\material-design-primary-container.png" Pack="true" PackagePath="\" />
+	</ItemGroup>
+
+	<!--SourceLink-->
+	<PropertyGroup>
+		<PublishRepositoryUrl>true</PublishRepositoryUrl>
+		<RepositoryType>git</RepositoryType>
+		<RepositoryUrl>https://github.com/Muckenbatscher/MaterialTheming</RepositoryUrl>
+		<PackageProjectUrl>https://github.com/Muckenbatscher/MaterialTheming</PackageProjectUrl>
+	</PropertyGroup>
+	<PropertyGroup Condition="'$(GITHUB_ACTIONS)' == 'true'">
+		<ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
+		<Deterministic>true</Deterministic>
+		<EmbedUntrackedSources>true</EmbedUntrackedSources>
+		<AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
+	</PropertyGroup>
+</Project>


### PR DESCRIPTION
To make it easier to use in WPF projects, without having to write the conversion to the native `System.Windows.Media.Color` class yourself.