### PR TITLE
Add extension methods to convert to System.Drawing.Color

### DIFF
--- a/.github/workflows/push_nuget_packages.yml
+++ b/.github/workflows/push_nuget_packages.yml
@@ -29,6 +29,8 @@ jobs:
         project: 
           - name: MaterialTheming
             path: 'MaterialTheming/MaterialTheming.csproj'
+          - name: MaterialTheming.Winforms
+            path: 'MaterialTheming.Winforms/MaterialTheming.Winforms.csproj'
 
     env:
       VERSION: ${{ needs.version.outputs.version }} 

--- a/.github/workflows/spell_check_readme.yml
+++ b/.github/workflows/spell_check_readme.yml
@@ -7,7 +7,6 @@ on:
     paths:
       - 'README.md'
 
-
 jobs:
   spell-check:
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,6 @@
 <Project>
 	
 	<PropertyGroup>
-		<ProduceReferenceAssembly>true</ProduceReferenceAssembly>
 		<LangVersion>14</LangVersion>
 		<Nullable>enable</Nullable>
 		<ImplicitUsings>enable</ImplicitUsings>

--- a/MaterialTheming.Winforms/MaterialTheming.Winforms.csproj
+++ b/MaterialTheming.Winforms/MaterialTheming.Winforms.csproj
@@ -1,0 +1,11 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>netstandard2.1;net48;net8.0;net10.0</TargetFrameworks>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\MaterialTheming\MaterialTheming.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/MaterialTheming.Winforms/SystemDrawingColorExtensions.cs
+++ b/MaterialTheming.Winforms/SystemDrawingColorExtensions.cs
@@ -1,0 +1,32 @@
+﻿using System.Drawing;
+
+namespace MaterialTheming;
+
+public static class SystemDrawingColorExtensions
+{
+    extension(RgbColor rgbColor)
+    {
+        public Color ToColor()
+        {
+            return Color.FromArgb(rgbColor.Red, rgbColor.Green, rgbColor.Blue);
+        }
+    }
+
+    extension(Color color)
+    {
+        public RgbColor ToRgbColor()
+        {
+            return RgbColor.FromRgb(color.R, color.G, color.B);
+        }
+    }
+
+    extension(HctColor hctColor)
+    {
+        public Color ToColor() => hctColor.ToRgbColor().ToColor();
+    }
+
+    extension(Color color)
+    {
+        public HctColor ToHctColor() => color.ToRgbColor().ToHct();
+    }
+}

--- a/MaterialTheming.slnx
+++ b/MaterialTheming.slnx
@@ -23,5 +23,6 @@
   </Folder>
   <Project Path="MaterialTheming.BlazorShowcase/MaterialTheming.BlazorShowcase.csproj" />
   <Project Path="MaterialTheming.Tests/MaterialTheming.Tests.csproj" />
+  <Project Path="MaterialTheming.Winforms/MaterialTheming.Winforms.csproj" />
   <Project Path="MaterialTheming/MaterialTheming.csproj" />
 </Solution>


### PR DESCRIPTION
To make it easier to integrate into Windows Forms projects.
Allows to convert to native `System.Drawing.Color` without having to write the conversion methods yourself.